### PR TITLE
Minor cleanup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "DittoSwiftLog",
-    platforms: [ .iOS(.v11), .macOS(.v11) ],
+    platforms: [ .iOS(.v14), .macOS(.v11) ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A sample implementation of how you could connect an external logging backend to [DittoSwiftPackage](https://github.com/getditto/DittoSwiftPackage)'s `DittoLogger` via the Custom Callback method. This sample bridges to Apple's [swift-log](https://github.com/apple/swift-log), allowing you to use any `swift-log` compatible backend.
+An implementation of how you could connect an external logging backend to [DittoSwiftPackage](https://github.com/getditto/DittoSwiftPackage)'s `DittoLogger` via the Custom Callback method. This sample bridges to Apple's [swift-log](https://github.com/apple/swift-log), allowing you to use any `swift-log` compatible backend.
 
 ## License (MIT)
 Copyright © 2024 Brian Plattenburg, DittoLive

--- a/Sources/DittoSwiftLog/Logger+Ditto.swift
+++ b/Sources/DittoSwiftLog/Logger+Ditto.swift
@@ -10,7 +10,7 @@ extension Logging.Logger {
     /// e.g. for some `Logger` `myLogger`: `DittoLogger.setCustomLogCallback(myLogger.dittoLoggerCallback(level:message:)`
     public func dittoLoggerCallback(level: DittoSwift.DittoLogLevel, message: String) {
         let translatedLogLevel = Logging.Logger.Level(dittoLevel: level)
-        let message = Logging.Logger.Message(stringLiteral: "[DittoSDK] \(message)")
+        let message = Logging.Logger.Message(stringLiteral: message)
         log(level: translatedLogLevel, message)
     }
 }


### PR DESCRIPTION
Update README, fix iOS min version to align to Ditto SDK, pass messages directly instead of adding data (consumers should use Logger metadata in swift-log instead)